### PR TITLE
chore(github-actions): change old set-output to env var output

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -19,10 +19,11 @@ jobs:
     steps:
       - name: Fetch remote repo
         id: repo-version
+        # echo "::set-output name=version::$v"
         run: |
           repo=https://github.com/${{ env.owner }}/${{ env.repo }}.git
           v=$(git ls-remote --tags --sort=-v:refname $repo | cut -f 1 | head -n 1)
-          echo "::set-output name=version::$v"
+          echo "{version}={$v}" >> $GITHUB_OUTPUT
 
   test:
     needs: [fetch]

--- a/versioner-runner.py
+++ b/versioner-runner.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import os
 import sys
 from versioner.versioner import get_java_version
 
@@ -7,7 +8,10 @@ if __name__ == '__main__':
   version = get_java_version()
   # Output different if we are in github actions.
   if len(sys.argv) == 2 and sys.argv[1] == "ga":
-    print(f"::set-output name=java-version::{version}")
+    # print(f"::set-output name=java-version::{version}")
+    name = "java-version"
+    with open(os.getenv('GITHUB_OUTPUT'), 'a') as env:
+      print(f'{name}={version}', file=env)
   elif 'help' in sys.argv:
     print("usage: ./versioner-runner.py ga")
     print("Output the least Java version supported for the current Gradle wrapper.")


### PR DESCRIPTION
From https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/, use the new env vars.